### PR TITLE
Replace function name check with `instanceof` 

### DIFF
--- a/src/srp.ts
+++ b/src/srp.ts
@@ -17,8 +17,8 @@ function assertIsBuffer(arg: Buffer, argname = "arg"): void {
   assert_(Buffer.isBuffer(arg), `Type error: ${argname} must be a buffer`);
 }
 
-function assertIsBigInteger(arg: BigInteger, argname?: string): void {
-  assert_(arg.constructor.name === "BigInteger", `Type error: ${argname} must be a BigInteger`);
+function assertIsBigInteger(arg: BigInteger, argname = "arg"): void {
+  assert_(arg instanceof BigInteger, `Type error: ${argname} must be a BigInteger`);
 }
 
 /**


### PR DESCRIPTION
After minification by tools such as webpack, `arg.constructor.name == 'BigInteger'` no longer works because the name would have been minified. Replacing the function name check with `arg instanceof BigInteger` fixes this issue.

Also, I added a default value to `argname` in `assertIsBigInteger` to make it consistent with `assertIsBuffer`.